### PR TITLE
fix: let Flyway use the pre-created auth schema (no CREATE SCHEMA)

### DIFF
--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -9,9 +9,15 @@ spring.datasource.password=${DATABASE_PASSWORD}
 
 spring.jpa.database=postgresql
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
-spring.jpa.hibernate.ddl-auto=update
+# Schema is owned by Flyway migrations (db/migration). Hibernate must not touch it.
+spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.default_schema=auth
+
+# The tm_<env>_auth role owns the `auth` schema but has no CREATE on the database,
+# so Flyway must NOT try to create the schema (the DB bootstrap already created it).
+# Local dev keeps create-schemas=true (base config) where the role can create schemas.
+spring.flyway.create-schemas=false
 
 # Actuator — expose only the health endpoint for the App Runner health check.
 management.endpoints.web.exposure.include=health

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,6 +1,6 @@
-CREATE SCHEMA IF NOT EXISTS auth;
-
-CREATE TABLE IF NOT EXISTS auth._user (
+-- Objects are created in the schema configured via spring.flyway.default-schema
+-- (`auth`), which the tm_<env>_auth role owns. No hard-coded schema name.
+CREATE TABLE IF NOT EXISTS _user (
     uuid        UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     user_name   TEXT NOT NULL UNIQUE,
     first_name  TEXT,


### PR DESCRIPTION
The tm_<env>_auth role owns its auth schema but has no CREATE on the database (least privilege), so Flyway's CREATE SCHEMA (create-schemas + the migration's own CREATE SCHEMA) failed with 'permission denied for database' and the service went CREATE_FAILED. The DB bootstrap already creates the schema, so:
- make V1__init.sql schema-neutral (drop CREATE SCHEMA + auth. qualifier)
- prod: spring.flyway.create-schemas=false (local dev keeps base true)
- prod: ddl-auto=none (Flyway owns the schema; was conflicting with =update)